### PR TITLE
Remove link translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,22 +35,16 @@ defaults:
           menu-title: 'Videos'
           mobile-title: 'Machines'
         about:
-          link: 'about'
           title: 'About'
         faq:
-          link: 'faq'
           title: 'FAQ'
         help-us:
-          link: 'help-us'
           title: 'Help Us'
         thanks:
-          link: 'thanks'
           title: 'Thanks'
         terms:
-          link: 'terms'
           title: 'Terms'
         contact:
-          link: 'contact'
           title: 'Contact'
         donate:
           title: 'Donate'
@@ -74,22 +68,16 @@ defaults:
           menu-title: 'Videos'
           mobile-title: 'Maschinen'
         about:
-          link: 'ueber'
           title: 'Über'
         faq:
-          link: 'faq'
           title: 'FAQ'
         help-us:
-          link: 'helfen'
           title: 'Helfen'
         thanks:
-          link: 'team'
           title: 'Team'
         terms:
-          link: 'bedingungen'
           title: 'Bedingungen'
         contact:
-          link: 'kontakt'
           title: 'Kontakt'
         donate:
           title: 'Spenden'

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,12 +2,12 @@
   <a href="/{{page.lang}}/" class="logo"></a>
 
   <nav>
-    <a href="/{{page.lang}}/{{page.translations.about.link}}">{{page.translations.about.title}}</a>
-    <a href="/{{page.lang}}/{{page.translations.faq.link}}">{{page.translations.faq.title}}</a>
-    <a href="/{{page.lang}}/{{page.translations.help-us.link}}">{{page.translations.help-us.title}}</a>
-    <a href="/{{page.lang}}/{{page.translations.thanks.link}}">{{page.translations.thanks.title}}</a>
-    <a href="/{{page.lang}}/{{page.translations.terms.link}}">{{page.translations.terms.title}}</a>
-    <a href="/{{page.lang}}/{{page.translations.contact.link}}">{{page.translations.contact.title}}</a>
+    <a href="/{{page.lang}}/about">{{page.translations.about.title}}</a>
+    <a href="/{{page.lang}}/faq">{{page.translations.faq.title}}</a>
+    <a href="/{{page.lang}}/help-us">{{page.translations.help-us.title}}</a>
+    <a href="/{{page.lang}}/thanks">{{page.translations.thanks.title}}</a>
+    <a href="/{{page.lang}}/terms">{{page.translations.terms.title}}</a>
+    <a href="/{{page.lang}}/contact">{{page.translations.contact.title}}</a>
     <a href="https://davehakkens.nl/donate/preciousplastic/">{{page.translations.donate.title}}</a>
   </nav>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -69,7 +69,7 @@ layout: default
         {% assign ln = page.translations %}
         {% assign words = "about_faq_help-us_thanks_terms_contact" | split: '_' %}
         {% for word in words %}
-          {% capture lnk %}/{{page.lang}}/{{ln.[word].link}}/{% endcapture %}
+          {% capture lnk %}/{{page.lang}}/{{word}}/{% endcapture %}
           <a href="{{lnk}}" {% if page.url == {{lnk}} %}class="current"{% endif %}>{{ln.[word].title}}</a>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
This pull request remove the ability to translate links. The links are now hardcoded into the footer.
