### PR TITLE
Skip pages of different languages in video menu

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,6 +33,10 @@ layout: default
             {% assign active = "" %}
             {% assign isVideo = false %}
 
+            {% if page.lang != node.lang %}
+              {% continue %}
+            {% endif %}
+
             {% capture idxurl %}/{{node.lang}}/videos/{% endcapture %}
             {% if page.url contains node.url and node.url != idxurl %}
               {% assign active = " current" %}


### PR DESCRIPTION
This refers to issue #72 on the double entries in the side menu. I'm sorry about these unfortunate bugs in the transition to multilingual sites. I suggest to do a thorough check before launching a translation of the site, to make sure things like these double menus don't occur. Let me know if I can help with this.
