### PR TITLE
link to youtube should be link to recycling spaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@
   <div class="text-landing">
     <div class="main-container">
       <div class="landing-text-wrapper">
-        <a href="https://www.youtube.com/" class="undeline-link-block landing-link mobile-link w-inline-block">
+        <a href="universe/recycling-spaces.html" class="undeline-link-block landing-link mobile-link w-inline-block">
           <div class="flex-arrow-link undeline-link center">
             <h5 class="text-button research-projects">Learn more about Precious Plastic spaces</h5>
           </div>


### PR DESCRIPTION
In mobile version the "Learn more about Precious Plastic spaces" link under Everyone is a recycler redirected to youtube.com 😬
so this should fix it